### PR TITLE
Link zur Keynote korrigiert

### DIFF
--- a/md/Aktionen/LIT-2017.md
+++ b/md/Aktionen/LIT-2017.md
@@ -32,7 +32,7 @@ Kontakt mit uns aufnehmen.
 Kontakt zu Vortragenden her. Wenn Sie möchten, können Sie anonym <strong><a
 href="https://etherpad.wikimedia.org/p/lit2017-post-mortem">Feedback</a></strong>
 abgeben. So helfen Sie uns, den Infotag nächstes Jahr noch besser zu
-machen. Vielen Dank dafür!</p>
+-machen. Vielen Dank dafür!</p>
 <p>Auf den Geschmack gekommen? Am <strong>6. Mai</strong> findet in
 Augsburg und zahlreichen weiteren Städten Deutschland und Europas der
 <strong><a href="/Aktionen/LPD-2017-1/">Linux Presentation
@@ -48,7 +48,7 @@ sich!</p>
 <table class="summary">
 <tr><th>Was?</th><td><strong>Vorträge und Informationsstände rund um die freie
 und sichere Windows-Alternative Linux sowie um unsere digitale Gesellschaft.
-<a href="https://www.youtube.com/watch?v=hOhz2BXR9Cs">Eröffnungsvortrag von Bernadette Längle</a>. <a
+<a href="https://www.youtube.com/watch?v=MKYUiZ0P4iE">Eröffnungsvortrag von Bernadette Längle</a>. <a
 href="https://frab.nixos.community/de/lit2017/public/schedule/0">Direkt zum
 Vortragsprogramm</a>. Es gibt auch eine <a
 href="https://play.google.com/store/apps/details?id=net.gaast.giggity">Android-App
@@ -200,7 +200,7 @@ Veranstaltungsort.</p>
   <tr>
     <td>09:45</td>
     <td colspan="6">
-      <strong><a href="https://www.youtube.com/watch?v=hOhz2BXR9Cs">Eröffnungsvortrag: Bernadette Längle</a></a></strong> (Raum&nbsp;A)
+      <strong><a href="https://www.youtube.com/watch?v=MKYUiZ0P4iE">Eröffnungsvortrag: Bernadette Längle</a></a></strong> (Raum&nbsp;A)
     </td>
   </tr>
 


### PR DESCRIPTION
Das Video der Keynote musste neu hochgeladen werden, den Link auf der LIT-2017 Seite habe ich korrigiert (an zwei Stellen).